### PR TITLE
Add /usr/local/share/applications to the list of desktop files paths.

### DIFF
--- a/obmenu-generator
+++ b/obmenu-generator
@@ -251,7 +251,8 @@ my %CONFIG = (
         terminalize            => 1,
         terminalization_format => q{%s -e '%s'},
 
-        desktop_files_paths => ['/usr/share/applications'],
+        desktop_files_paths => ['/usr/share/applications',
+				'/usr/local/share/applications'],
 
         icon_dirs_first  => undef,
         icon_dirs_second => undef,


### PR DESCRIPTION
Hi,

this path is quite standard, at least on Debian, for everything that was not installed using the package manager.

Just out of curiosity, I see that there is a config file for obmenu-generator in `~/.config`, but it's generated and modifications are lost. So, the only way to change configuration is to modify obmenu-generator itself, isn't it ? Or is there another way ?