### PR TITLE
OpenBSD Patches | "AnyDBM_File" error occured

### DIFF
--- a/obmenu-generator
+++ b/obmenu-generator
@@ -32,6 +32,7 @@ use 5.014;
 #use strict;
 #use warnings;
 
+use DB_File;
 use Linux::DesktopFiles;
 
 my $pkgname = 'obmenu-generator';


### PR DESCRIPTION
Without this line it give a "AnyDBM_File doesn't define an EXISTS method at ./obmenu-generator line 496."