### PR TITLE
Append "applications" to XDG_DATA_DIRS when looking for .desktop

### DIFF
--- a/obmenu-generator
+++ b/obmenu-generator
@@ -314,7 +314,7 @@ if ($CONFIG{VERSION} != $version) {
 my @desktop_files_paths = do {
     my %seen;
     grep { !$seen{$_}++ } (
-        ($ENV{XDG_DATA_DIRS} ? split(/:/, $ENV{XDG_DATA_DIRS}) : ()),
+        (map { $_ . '/applications' } ($ENV{XDG_DATA_DIRS} ? split(/:/, $ENV{XDG_DATA_DIRS}) : ())),
         @{$CONFIG{'Linux::DesktopFiles'}{desktop_files_paths}},
     );
 };


### PR DESCRIPTION
I was wondering why flatpak applications didn't appear, when they are listed in XDG_DATA_DIRS, the code looking at XDG_DATA_DIRS didnt check in data_dir/applications for the desktop/icon files, this seems to fix it